### PR TITLE
Add Media model and request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2021-01-20
+### Added
+- Media model
+- MediaUpdate Model
+- Media#create
+
 ## [1.5.2] - 2021-01-08
 ### Added
 - Visit#Type

--- a/lib/redox.rb
+++ b/lib/redox.rb
@@ -12,6 +12,8 @@ require 'redox/models/provider'
 require 'redox/models/visit'
 require 'redox/models/transaction'
 require 'redox/models/financial'
+require 'redox/models/media'
+require 'redox/models/media_upload'
 require 'redox/models/patient/demographics'
 require 'redox/models/patient/contacts'
 require 'redox/models/patient/identifier'
@@ -25,6 +27,7 @@ require 'redox/request/patient_admin'
 require 'redox/request/patient_search'
 require 'redox/request/provider'
 require 'redox/request/scheduling'
+require 'redox/request/media'
 
 module Redox
   class Configuration

--- a/lib/redox/models/media.rb
+++ b/lib/redox/models/media.rb
@@ -1,0 +1,19 @@
+module Redox
+  module Models
+    class Media < AbstractModel
+      property :FileType, from: :file_type, required: false
+      property :FileName, from: :file_name, required: false
+      property :FileContents, from: :file_contents, required: false
+      property :DocumentType, from: :document_type, required: false
+      property :DocumentID, from: :document_id, required: false
+      property :Availability, from: :availability, required: false
+
+      alias_method  :file_type, :FileType
+      alias_method  :file_name, :FileName
+      alias_method  :file_contents, :FileContents
+      alias_method  :document_type, :DocumentType
+      alias_method  :document_id, :DocumentID
+      alias_method  :availability, :Availability
+    end
+  end
+end

--- a/lib/redox/models/media_upload.rb
+++ b/lib/redox/models/media_upload.rb
@@ -1,0 +1,13 @@
+module Redox
+  module Models
+    class MediaUpload < AbstractModel
+      property :Patient, required: false, from: :patient, default: Redox::Models::Patient.new
+      property :Visit, required: false, from: :visit, default: Redox::Models::Visit.new
+      property :Media, required: false, from: :media, default: Redox::Models::Media.new
+
+      alias_method :patient, :Patient
+      alias_method :visit, :Visit
+      alias_method :media, :Media
+    end
+  end
+end

--- a/lib/redox/request/media.rb
+++ b/lib/redox/request/media.rb
@@ -1,0 +1,12 @@
+module Redox
+  module Request
+    class Media
+      CREATE_META = Redox::Models::Meta.new(EventType: 'New', DataModel: 'Media')
+
+      def self.create(model, meta: Redox::Models::Meta.new)
+        meta = CREATE_META.merge(meta)
+        return Redox::Models::Model.from_response((RedoxClient.connection.request(body: Redox::Request.build_body(model, meta))))
+      end
+    end
+  end
+end

--- a/lib/redox/version.rb
+++ b/lib/redox/version.rb
@@ -1,3 +1,3 @@
 module Redox
-  VERSION = '1.5.2'.freeze
+  VERSION = '1.6.0'.freeze
 end

--- a/test/redox/models/media_upload_test.rb
+++ b/test/redox/models/media_upload_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class MediaUploadTest < Minitest::Test
+  describe 'media_upload' do
+    let(:media_upload) { Redox::Models::MediaUpload.new(data) }
+    let(:data) { {} }
+    describe 'default' do
+      it 'has a patient' do
+        assert_equal(Redox::Models::Patient, media_upload.patient.class)
+      end
+
+      it 'has a media' do
+        assert_equal(Redox::Models::Media, media_upload.media.class)
+      end
+
+      it 'has a visit' do
+        assert_equal(Redox::Models::Visit, media_upload.visit.class)
+      end
+    end
+
+    describe 'media' do
+      it 'can be initialized' do
+        media_upload = Redox::Models::MediaUpload.new('Media' => {'FileName' => 'test.pdf'})
+
+        assert_equal('test.pdf', media_upload.media['FileName'])
+      end
+
+      it 'can be built' do
+        media_upload = Redox::Models::MediaUpload.new
+
+        media_upload.media['FileName'] = 'test.jpg'
+        assert_equal('test.jpg', media_upload.media['FileName'])
+      end
+    end
+  end
+end

--- a/test/redox/request/media_test.rb
+++ b/test/redox/request/media_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+module Request
+  class MediaTest < Minitest::Test
+    describe 'MediaUpload' do
+      describe 'redox calls' do
+        let(:request_body) { JSON.parse(@actual_request.body) }
+        let(:sample) { load_sample('media.response.json', parse: true) }
+        let(:media_upload) { Redox::Models::MediaUpload.new(data) }
+        let(:response) { request }
+        let(:data) { {} }
+
+        before do
+          stub_redox(body: sample)
+
+          WebMock.after_request do |actual_request, actual_response|
+            @actual_request = actual_request
+          end
+
+          request
+        end
+
+        describe '#create' do
+          let(:request) { Redox::Request::Media.create(media_upload) }
+
+          describe 'request' do
+            it 'has an endpoint' do
+              assert_requested(@post_stub, times: 1)
+            end
+
+            it 'sends meta' do
+              assert_equal('New', Redox::Models::Meta.new(request_body).EventType)
+              assert_equal('Media', Redox::Models::Meta.new(request_body).DataModel)
+            end
+
+            it 'sends data' do
+              assert_equal(false, request_body['Media'].nil?)
+              assert_equal(false, request_body['Patient'].nil?)
+              assert_equal(false, request_body['Visit'].nil?)
+            end
+          end
+
+          describe 'response' do
+            it 'returns a valid response' do
+              assert(response.is_a?(Redox::Models::Model))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/samples/media.response.json
+++ b/test/samples/media.response.json
@@ -1,0 +1,203 @@
+{
+  "Meta": {
+    "DataModel": "Media",
+    "EventType": "New",
+    "EventDateTime": "2021-01-19T19:24:09.752Z",
+    "Test": true,
+    "Source": {
+      "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+      "Name": "Redox Dev Tools"
+    },
+    "Destinations": [
+      {
+        "ID": "af394f14-b34a-464f-8d24-895f370af4c9",
+        "Name": "Redox EMR"
+      }
+    ],
+    "Message": {
+      "ID": 5565
+    },
+    "Transmission": {
+      "ID": 12414
+    },
+    "FacilityCode": null
+  },
+  "Patient": {
+    "Identifiers": [
+      {
+        "ID": "0000000001",
+        "IDType": "MR"
+      },
+      {
+        "ID": "e167267c-16c9-4fe3-96ae-9cff5703e90a",
+        "IDType": "EHRID"
+      },
+      {
+        "ID": "a1d4ee8aba494ca",
+        "IDType": "NIST"
+      }
+    ],
+    "Demographics": {
+      "FirstName": "Timothy",
+      "MiddleName": "Paul",
+      "LastName": "Bixby",
+      "DOB": "2008-01-06",
+      "SSN": "101-01-0001",
+      "Sex": "Male",
+      "Race": "White",
+      "IsHispanic": null,
+      "MaritalStatus": "Married",
+      "IsDeceased": null,
+      "DeathDateTime": null,
+      "PhoneNumber": {
+        "Home": "+18088675301",
+        "Office": null,
+        "Mobile": null
+      },
+      "EmailAddresses": [],
+      "Language": "en",
+      "Citizenship": [],
+      "Address": {
+        "StreetAddress": "4762 Hickory Street",
+        "City": "Monroe",
+        "State": "WI",
+        "ZIP": "53566",
+        "County": "Green",
+        "Country": "US"
+      }
+    },
+    "Notes": []
+  },
+  "Visit": {
+    "VisitNumber": "1234",
+    "AccountNumber": null,
+    "Location": {
+      "Type": null,
+      "Facility": null,
+      "Department": null,
+      "Room": null,
+      "Bed": null
+    }
+  },
+  "Media": {
+    "FileType": "PDF",
+    "FileName": "SamplePDF",
+    "FileContents": "<...base 64 file contents...>",
+    "DocumentType": "Empty File",
+    "DocumentID": "b169267c-10c9-4fe3-91ae-9ckf5703e90l",
+    "DocumentDescription": null,
+    "CreationDateTime": "2017-06-22T19:30:04.387Z",
+    "ServiceDateTime": "2017-06-22T17:00:00.387Z",
+    "Provider": {
+      "ID": "4356789876",
+      "IDType": "NPI",
+      "FirstName": "Pat",
+      "LastName": "Granite",
+      "Credentials": [
+        "MD"
+      ],
+      "Address": {
+        "StreetAddress": "123 Main St.",
+        "City": "Madison",
+        "State": "WI",
+        "ZIP": "53703",
+        "County": "Dane",
+        "Country": "USA"
+      },
+      "EmailAddresses": [],
+      "PhoneNumber": {
+        "Office": "+16085551234"
+      },
+      "Location": {
+        "Type": null,
+        "Facility": null,
+        "Department": null,
+        "Room": null
+      }
+    },
+    "Authenticated": "False",
+    "Authenticator": {
+      "ID": null,
+      "IDType": null,
+      "FirstName": null,
+      "LastName": null,
+      "Credentials": [],
+      "Address": {
+        "StreetAddress": null,
+        "City": null,
+        "State": null,
+        "ZIP": null,
+        "County": null,
+        "Country": null
+      },
+      "EmailAddresses": [],
+      "PhoneNumber": {
+        "Office": null
+      },
+      "Location": {
+        "Type": null,
+        "Facility": null,
+        "Department": null,
+        "Room": null
+      }
+    },
+    "Availability": "Unavailable",
+    "Notifications": [
+      {
+        "ID": "2434534567",
+        "IDType": "NPI",
+        "FirstName": "Sharon",
+        "LastName": "Chalk",
+        "Credentials": [
+          "MD",
+          "PhD"
+        ],
+        "Address": {
+          "StreetAddress": "312 Maple Dr. Suite 400",
+          "City": "Verona",
+          "State": "WI",
+          "ZIP": "53593",
+          "County": "Dane",
+          "Country": "USA"
+        },
+        "EmailAddresses": [],
+        "PhoneNumber": {
+          "Office": "+16085559999"
+        },
+        "Location": {
+          "Type": null,
+          "Facility": null,
+          "Department": null,
+          "Room": null
+        }
+      },
+      {
+        "ID": "8263749385",
+        "IDType": "NPI",
+        "FirstName": "Jim",
+        "LastName": "Mica",
+        "Credentials": [
+          "RN"
+        ],
+        "Address": {
+          "StreetAddress": "5235 Kennedy Ave.",
+          "City": "Creve Cour",
+          "State": "MO",
+          "ZIP": "63141",
+          "County": "Saint Louis",
+          "Country": "USA"
+        },
+        "EmailAddresses": [],
+        "PhoneNumber": {
+          "Office": "+13145557777"
+        },
+        "Location": {
+          "Type": null,
+          "Facility": null,
+          "Department": null,
+          "Room": null
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a media request allowing the `create` event on the `Media` model.
Also adds a `Media` model and a `MediaUpload` model as a helper for
creating the request.