### PR TITLE
accounting-for-redox-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.8.6] - 2023-05-12
+### Changed
+- Updated test JSON files for update retiring Meta.Message.ID and Meta.Transmission.ID
+
 ## [1.8.5] - 2023-02-16
 ### Added
 - Notifications to Media Model
@@ -203,6 +207,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial Release
 
+[1.8.6]: https://github.com/WeInfuse/redox/compare/v1.8.5...v1.8.6
 [1.8.5]: https://github.com/WeInfuse/redox/compare/v1.8.4...v1.8.5
 [1.8.4]: https://github.com/WeInfuse/redox/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/WeInfuse/redox/compare/v1.8.2...v1.8.3

--- a/lib/redox/version.rb
+++ b/lib/redox/version.rb
@@ -1,3 +1,3 @@
 module Redox
-  VERSION = '1.8.5'.freeze
+  VERSION = '1.8.6'.freeze
 end

--- a/test/samples/error.response.json
+++ b/test/samples/error.response.json
@@ -2,9 +2,12 @@
    "Meta": {
       "DataModel": "PatientSearch",
       "EventType": "Query",
-      "Message": {
-         "ID": 1135210193
-      },
+      "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
       "Source": {
          "ID": "x72i2ec6-de0b-471a-a6d5-41b786c93c17",
          "Name": "Development Source"

--- a/test/samples/financial_transaction.response.json
+++ b/test/samples/financial_transaction.response.json
@@ -14,12 +14,12 @@
         "Name": "Redox EMR"
       }
     ],
-    "Message": {
-      "ID": 5565
-    },
-    "Transmission": {
-      "ID": 12414
-    },
+    "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
     "FacilityCode": null
   },
   "Patient": {

--- a/test/samples/financial_transaction.response.json
+++ b/test/samples/financial_transaction.response.json
@@ -15,11 +15,11 @@
       }
     ],
     "Logs": [
-         {
-            "ID": 1234567890,
-            "AttemptID": 987654321
-         }
-      ],
+      {
+        "ID": 1234567890,
+        "AttemptID": 987654321
+      }
+    ],
     "FacilityCode": null
   },
   "Patient": {

--- a/test/samples/media.response.json
+++ b/test/samples/media.response.json
@@ -14,12 +14,12 @@
         "Name": "Redox EMR"
       }
     ],
-    "Message": {
-      "ID": 5565
-    },
-    "Transmission": {
-      "ID": 12414
-    },
+    "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
     "FacilityCode": null
   },
   "Patient": {

--- a/test/samples/media.response.json
+++ b/test/samples/media.response.json
@@ -15,11 +15,11 @@
       }
     ],
     "Logs": [
-         {
-            "ID": 1234567890,
-            "AttemptID": 987654321
-         }
-      ],
+      {
+        "ID": 1234567890,
+        "AttemptID": 987654321
+      }
+    ],
     "FacilityCode": null
   },
   "Patient": {

--- a/test/samples/medications.response.json
+++ b/test/samples/medications.response.json
@@ -20,12 +20,6 @@
             "AttemptID": "925d1617-2fe0-468c-a14c-f8c04b572c54"
          }
       ],
-      "Message": {
-         "ID": 5565
-      },
-      "Transmission": {
-         "ID": 12414
-      },
       "FacilityCode": null
    },
    "Patient": {

--- a/test/samples/patient_search_multiple_matches.response.json
+++ b/test/samples/patient_search_multiple_matches.response.json
@@ -109,9 +109,12 @@
    "Meta": {
       "DataModel": "PatientSearch",
       "EventType": "Query",
-      "Message": {
-         "ID": 4033535541
-      },
+      "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
       "Source": {
          "ID": "e15d3ec6-de0b-471a-a6d5-41b786c93c17"
       },

--- a/test/samples/registration.response.json
+++ b/test/samples/registration.response.json
@@ -14,12 +14,12 @@
             "Name": "Redox EMR"
          }
       ],
-      "Message": {
-         "ID": 5565
-      },
-      "Transmission": {
-         "ID": 12414
-      },
+      "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
       "FacilityCode": null
    },
    "Patient": {

--- a/test/samples/scheduling.response.json
+++ b/test/samples/scheduling.response.json
@@ -14,12 +14,12 @@
             "Name": "Redox EMR"
          }
       ],
-      "Message": {
-         "ID": 5565
-      },
-      "Transmission": {
-         "ID": 12414
-      },
+      "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
       "FacilityCode": null
    },
    "Patient": {

--- a/test/samples/visit_update.response.json
+++ b/test/samples/visit_update.response.json
@@ -14,12 +14,12 @@
             "Name": "Redox EMR"
          }
       ],
-      "Message": {
-         "ID": 5565
-      },
-      "Transmission": {
-         "ID": 12414
-      },
+      "Logs": [
+         {
+            "ID": 1234567890,
+            "AttemptID": 987654321
+         }
+      ],
       "FacilityCode": null
    },
    "Patient": {


### PR DESCRIPTION
Updated all Redox test JSON files to account for update retiring “Meta.Message.ID” and “Meta.Transmission.ID” fields