### PR TITLE
Add oauth authentication support for FHIR and Platform APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,16 @@ response.meta
 
 ```ruby
 Redox.configure do |c|
-  c.api_key      = ENV['REDOX_API_KEY']
-  c.secret       = ENV['REDOX_SECRET']
+  # legacy keys
+  c.api_key = ENV['REDOX_API_KEY']
+  c.secret = ENV['REDOX_SECRET']
+  # FHIR oauth keys
+  c.fhir_client_id = ENV['REDOX_FHIR_CLIENT_ID']
+  c.fhir_private_key = ENV['REDOX_FHIR_PRIVATE_KEY']
+  # platform oauth keys
+  c.platform_client_id = ENV['REDOX_PLATFORM_CLIENT_ID']
+  c.platform_private_key = ENV['REDOX_PLATFORM_PRIVATE_KEY']
+
   c.api_endpoint = 'http://hello.com' # Defaults to Redox endpoint
   c.token_expiry_padding = 120 # Defaults to 60 seconds
 end
@@ -111,7 +119,7 @@ end
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 If you have already merged changes into the master branch of this repo and are looking to release a new version, remember to switch out of your local feature branch (if you are on one) to the master or main branch of this repo. Then pull all changes down so you have an up to date code base.
 

--- a/lib/redox.rb
+++ b/lib/redox.rb
@@ -4,6 +4,8 @@ require 'redox/version'
 require 'redox/redox_exception'
 require 'redox/connection'
 require 'redox/authentication'
+require 'redox/fhir_authentication'
+require 'redox/platform_authentication'
 require 'redox/models/model'
 require 'redox/models/meta'
 require 'redox/models/ordering_provider'
@@ -40,11 +42,13 @@ require 'redox/request/medications'
 
 module Redox
   class Configuration
-    attr_accessor :api_key, :secret
+    attr_accessor :fhir_client_id, :fhir_private_key, :platform_client_id, :platform_private_key
 
     def initialize
-      @api_key  =  nil
-      @secret   =  nil
+      @fhir_client_id =  nil
+      @fhir_private_key =  nil
+      @platform_client_id = nil
+      @platform_private_key = nil
     end
 
     def api_endpoint=(endpoint)
@@ -52,33 +56,37 @@ module Redox
     end
 
     def api_endpoint
-      return Connection.base_uri
+      Connection.base_uri
     end
 
     def token_expiry_padding=(time_in_seconds)
-      Authentication.token_expiry_padding = time_in_seconds
+      FHIRAuthentication.token_expiry_padding = time_in_seconds
     end
 
     def token_expiry_padding
-      return Authentication.token_expiry_padding
+      FHIRAuthentication.token_expiry_padding
     end
 
     def to_h
-      return {
-        api_key: @api_key,
-        secret: @secret,
+      {
+        fhir_client_id: @fhir_client_id,
+        fhir_private_key: @fhir_private_key,
+        platform_client_id: @platform_client_id,
+        platform_private_key: @platform_private_key,
         api_endpoint: api_endpoint,
         token_expiry_padding: token_expiry_padding
       }
     end
 
     def from_h(h)
-      self.api_key = h[:api_key]
-      self.secret  = h[:secret]
+      self.fhir_client_id = h[:fhir_client_id]
+      self.fhir_private_key = h[:fhir_private_key]
+      self.platform_client_id = h[:platform_client_id]
+      self.platform_private_key = h[:platform_private_key]
       self.api_endpoint = h[:api_endpoint]
       self.token_expiry_padding = h[:token_expiry_padding]
 
-      return self
+      self
     end
   end
 

--- a/lib/redox.rb
+++ b/lib/redox.rb
@@ -3,8 +3,10 @@ require 'hashie'
 require 'redox/version'
 require 'redox/redox_exception'
 require 'redox/connection'
+require 'redox/legacy_connection'
 require 'redox/authentication'
 require 'redox/fhir_authentication'
+require 'redox/legacy_authentication'
 require 'redox/platform_authentication'
 require 'redox/models/model'
 require 'redox/models/meta'
@@ -42,9 +44,14 @@ require 'redox/request/medications'
 
 module Redox
   class Configuration
-    attr_accessor :fhir_client_id, :fhir_private_key, :platform_client_id, :platform_private_key
+    attr_accessor :api_key, :secret, :fhir_client_id, :fhir_private_key, :platform_client_id, :platform_private_key
 
     def initialize
+      # legacy
+      @api_key = nil
+      @secret = nil
+
+      # oauth
       @fhir_client_id =  nil
       @fhir_private_key =  nil
       @platform_client_id = nil
@@ -69,6 +76,8 @@ module Redox
 
     def to_h
       {
+        api_key: @api_key,
+        secret: @secret,
         fhir_client_id: @fhir_client_id,
         fhir_private_key: @fhir_private_key,
         platform_client_id: @platform_client_id,
@@ -79,6 +88,9 @@ module Redox
     end
 
     def from_h(h)
+      self.api_key = h[:api_key]
+      self.secret = h[:secret]
+
       self.fhir_client_id = h[:fhir_client_id]
       self.fhir_private_key = h[:fhir_private_key]
       self.platform_client_id = h[:platform_client_id]

--- a/lib/redox/authentication.rb
+++ b/lib/redox/authentication.rb
@@ -1,77 +1,105 @@
+require 'json/jwt'
+require 'jwt'
+
 module Redox
-  class Authentication < Connection
-    attr_accessor :response
+  module Authentication
+    attr_reader :client_id, :environment, :private_key
 
-    BASE_ENDPOINT    = '/auth'.freeze
+    AUTH_URL = 'https://api.redoxengine.com/v2/auth/token'
 
-    AUTH_ENDPOINT    = "#{BASE_ENDPOINT}/authenticate".freeze
+    # TODO: needed for tests...
+    BASE_ENDPOINT = '/v2/auth'.freeze
+    AUTH_ENDPOINT = "#{BASE_ENDPOINT}/token".freeze
     REFRESH_ENDPOINT = "#{BASE_ENDPOINT}/refreshToken".freeze
 
-    class << self
-      attr_accessor :token_expiry_padding
-
-      @@token_expiry_padding = 0
-    end
-
-    def initialize
-      @response = nil
-    end
-
     def authenticate
-      if (self.expires?)
-        if (self.refresh_token)
-          request = {
-            body: { apiKey: Redox.configuration.api_key, refreshToken: self.refresh_token },
-            endpoint: REFRESH_ENDPOINT
-          }
-        else
-          request = {
-            body: { apiKey: Redox.configuration.api_key, secret: Redox.configuration.secret },
-            endpoint: AUTH_ENDPOINT
-          }
-        end
+      # debugger
+      jwt_token = generate_jwt
+      payload = {
+        body: {
+          grant_type: 'client_credentials',
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          client_assertion: jwt_token
+        }
+      }
+      @last_auth_time = Time.now.utc
+      response = HTTParty.post(AUTH_URL, payload)
 
-        response = self.request(**request, auth: false)
-
-        if (false == response.ok?)
-          @response = nil
-          raise RedoxException.from_response(response, msg: 'Authentication')
-        else
-          @response = response
-        end
-      end
-
-      return self
-    end
-
-    def access_token
-      return @response['accessToken'] if @response
-    end
-
-    def expiry
-      return @response['expires'] if @response
-    end
-
-    def refresh_token
-      return @response['refreshToken'] if @response
-    end
-
-    def expires?(seconds_from_now = Authentication.token_expiry_padding)
-      if (self.expiry)
-        return DateTime.strptime(self.expiry, Models::Meta::FROM_DATETIME_FORMAT).to_time.utc <= (Time.now + seconds_from_now).utc
+      if response.ok?
+        @response = response
       else
-        return true
+        @response = nil
+        raise RedoxException.from_response(response, msg: 'Authentication')
       end
+
+      self
     end
 
     def access_header
-      return {
-        'Authorization' => "Bearer #{self.access_token}",
-      }
+      { 'Authorization' => "Bearer #{access_token}" }
     end
 
-    def expire!
-      @response = nil
+    def access_token
+      @response['access_token'] if @response
+    end
+
+    def expired?
+      @last_auth_time + @response['expires_in'] < (Time.now + self.class.token_expiry_padding).utc
+    end
+
+    private
+
+    def generate_jwt(audience = AUTH_URL)
+      private_key = extract_private_key
+      kid_value = extract_or_generate_kid(private_key)
+
+      payload = {
+        iss: client_id,
+        sub: client_id,
+        aud: audience,
+        exp: 5.minutes.from_now.to_i,
+        iat: Time.now.to_i,
+        jti: SecureRandom.uuid
+      }
+
+      # Use private_key directly if it's an instance of OpenSSL::PKey::RSA
+      key_for_jwt = private_key.is_a?(OpenSSL::PKey::RSA) ? private_key : private_key.to_key
+      headers = { kid: kid_value, alg: 'RS384' }
+
+      # Sign the JWT with the appropriate private key and RS384 algorithm that Redox supports
+      # debugger
+      JWT.encode(payload, key_for_jwt, 'RS384', headers)
+    end
+
+    # Parse either the keyjwk or pem value depending on availability
+    def extract_private_key
+      if private_key.is_a?(String) && valid_json?(private_key)
+        JSON::JWK.new(JSON.parse(private_key))
+      elsif private_key.is_a?(String)
+        OpenSSL::PKey::RSA.new(private_key)
+      else
+        raise 'Invalid private key format. Expected JSON or PEM string.'
+      end
+    end
+
+    def extract_or_generate_kid(key)
+      if key.is_a?(JSON::JWK)
+        key[:kid]
+      elsif key.is_a?(OpenSSL::PKey::RSA)
+        digest = OpenSSL::Digest.new('SHA256')
+        Base64.urlsafe_encode64(digest.digest(key.to_der)).strip
+      else
+        raise 'Unsupported key type for generating kid.'
+      end
+    end
+
+    def valid_json?(json)
+      return false if json.nil?
+
+      JSON.parse(json)
+      true
+    rescue JSON::ParserError
+      false
     end
   end
 end

--- a/lib/redox/authentication.rb
+++ b/lib/redox/authentication.rb
@@ -7,7 +7,6 @@ module Redox
 
     AUTH_URL = 'https://api.redoxengine.com/v2/auth/token'
 
-    # TODO: needed for tests....
     BASE_ENDPOINT = '/v2/auth'.freeze
     AUTH_ENDPOINT = "#{BASE_ENDPOINT}/token".freeze
     REFRESH_ENDPOINT = "#{BASE_ENDPOINT}/refreshToken".freeze

--- a/lib/redox/authentication.rb
+++ b/lib/redox/authentication.rb
@@ -47,6 +47,14 @@ module Redox
       @last_auth_time + @response['expires_in'] < (Time.now + self.class.token_expiry_padding).utc
     end
 
+    def expires?(seconds_from_now = self.class.token_expiry_padding)
+      @last_auth_time + @response['expires_in'].to_i < (Time.now + seconds_from_now).utc
+    end
+
+    def expire!
+      @response = nil
+    end
+
     private
 
     def generate_jwt(audience = AUTH_URL)

--- a/lib/redox/connection.rb
+++ b/lib/redox/connection.rb
@@ -10,11 +10,18 @@ module Redox
 
     format :json
 
-    def request(endpoint: DEFAULT_ENDPOINT, body: nil, headers: {}, auth: true)
+    def post(endpoint: DEFAULT_ENDPOINT, body: nil, headers: {}, auth: true)
       body    = body.to_json if body.is_a?(Hash)
       headers = auth_header(auth_class(endpoint)).merge(headers) if auth
 
       self.class.post(endpoint, body: body, headers: headers)
+    end
+    alias :request :post
+
+    def get(endpoint:, headers: {}, auth: true)
+      headers = auth_header(auth_class(endpoint)).merge(headers) if auth
+
+      self.class.get(endpoint, headers: headers)
     end
 
     private

--- a/lib/redox/connection.rb
+++ b/lib/redox/connection.rb
@@ -12,17 +12,21 @@ module Redox
 
     def request(endpoint: DEFAULT_ENDPOINT, body: nil, headers: {}, auth: true)
       body    = body.to_json if body.is_a?(Hash)
-      headers = auth_header.merge(headers) if auth
+      headers = auth_header(auth_class(endpoint)).merge(headers) if auth
 
       self.class.post(endpoint, body: body, headers: headers)
     end
 
     private
 
-    def auth_header
-      @auth ||= Authentication.new
+    def auth_class(endpoint)
+      endpoint.start_with?('/platform') ? PlatformAuthentication : FHIRAuthentication
+    end
 
-      return @auth.authenticate.access_header
+    def auth_header(klass)
+      @auth ||= klass.new
+
+      @auth.authenticate.access_header
     end
   end
 end

--- a/lib/redox/fhir_authentication.rb
+++ b/lib/redox/fhir_authentication.rb
@@ -1,0 +1,16 @@
+module Redox
+  class FHIRAuthentication < Connection
+    include Authentication
+
+    class << self
+      attr_accessor :token_expiry_padding
+
+      @@token_expiry_padding = 0
+    end
+
+    def initialize
+      @client_id = Redox.configuration.fhir_client_id
+      @private_key = Redox.configuration.fhir_private_key
+    end
+  end
+end

--- a/lib/redox/legacy_authentication.rb
+++ b/lib/redox/legacy_authentication.rb
@@ -1,0 +1,77 @@
+module Redox
+  class LegacyAuthentication < LegacyConnection
+    attr_accessor :response
+
+    BASE_ENDPOINT    = '/auth'.freeze
+
+    AUTH_ENDPOINT    = "#{BASE_ENDPOINT}/authenticate".freeze
+    REFRESH_ENDPOINT = "#{BASE_ENDPOINT}/refreshToken".freeze
+
+    class << self
+      attr_accessor :token_expiry_padding
+
+      @@token_expiry_padding = 0
+    end
+
+    def initialize
+      @response = nil
+    end
+
+    def authenticate
+      if (self.expires?)
+        if (self.refresh_token)
+          request = {
+            body: { apiKey: Redox.configuration.api_key, refreshToken: self.refresh_token },
+            endpoint: REFRESH_ENDPOINT
+          }
+        else
+          request = {
+            body: { apiKey: Redox.configuration.api_key, secret: Redox.configuration.secret },
+            endpoint: AUTH_ENDPOINT
+          }
+        end
+
+        response = self.request(**request, auth: false)
+
+        if (false == response.ok?)
+          @response = nil
+          raise RedoxException.from_response(response, msg: 'Authentication')
+        else
+          @response = response
+        end
+      end
+
+      return self
+    end
+
+    def access_token
+      return @response['accessToken'] if @response
+    end
+
+    def expiry
+      return @response['expires'] if @response
+    end
+
+    def refresh_token
+      return @response['refreshToken'] if @response
+    end
+
+    def expires?(seconds_from_now = LegacyAuthentication.token_expiry_padding)
+      if (self.expiry)
+        return DateTime.strptime(self.expiry, Models::Meta::FROM_DATETIME_FORMAT).to_time.utc <= (Time.now + seconds_from_now).utc
+      else
+        return true
+      end
+    end
+
+    def access_header
+      return {
+        'Authorization' => "Bearer #{self.access_token}",
+      }
+    end
+
+    def expire!
+      @response = nil
+    end
+  end
+end

--- a/lib/redox/legacy_connection.rb
+++ b/lib/redox/legacy_connection.rb
@@ -1,0 +1,28 @@
+module Redox
+  class LegacyConnection
+    DEFAULT_ENDPOINT = '/endpoint'.freeze
+
+    include HTTParty
+
+    base_uri 'https://api.redoxengine.com/'.freeze
+
+    headers 'Content-Type' => 'application/json'
+
+    format :json
+
+    def request(endpoint: DEFAULT_ENDPOINT, body: nil, headers: {}, auth: true)
+      body    = body.to_json if body.is_a?(Hash)
+      headers = auth_header.merge(headers) if auth
+
+      self.class.post(endpoint, body: body, headers: headers)
+    end
+
+    private
+
+    def auth_header
+      @auth ||= LegacyAuthentication.new
+
+      @auth.authenticate.access_header
+    end
+  end
+end

--- a/lib/redox/platform_authentication.rb
+++ b/lib/redox/platform_authentication.rb
@@ -1,0 +1,16 @@
+module Redox
+  class PlatformAuthentication < Connection
+    include Authentication
+
+    class << self
+      attr_accessor :token_expiry_padding
+
+      @@token_expiry_padding = 0
+    end
+
+    def initialize
+      @client_id = Redox.configuration.platform_client_id
+      @private_key = Redox.configuration.platform_private_key
+    end
+  end
+end

--- a/redox.gemspec
+++ b/redox.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'httparty', '~> 0.18'
   spec.add_dependency 'hashie', '~> 3.5'
+  spec.add_dependency 'json-jwt', '~> 1.16'
+  spec.add_dependency 'jwt', '~> 2.8'
   spec.add_development_dependency 'bundler', '>=1', '<3'
   spec.add_development_dependency 'byebug', '~> 11'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/test/redox/connection_test.rb
+++ b/test/redox/connection_test.rb
@@ -21,7 +21,7 @@ class ConnectionTest < Minitest::Test
 
     describe 'auth option' do
       it 'defaults to sending auth header' do
-        @connection.request()
+        @connection.request
 
         assert_requested(@auth_stub, times: 1)
         assert_requested(@authorized_stub, times: 1)
@@ -35,7 +35,7 @@ class ConnectionTest < Minitest::Test
     end
 
     it 'returns response' do
-      response = @connection.request()
+      response = @connection.request
 
       assert(response.ok?)
       assert_equal({}, response.parsed_response)

--- a/test/redox/fhir_authentication_test.rb
+++ b/test/redox/fhir_authentication_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AuthenticationTest < Minitest::Test
+class FHIRAuthenticationTest < Minitest::Test
   describe 'authentication' do
     before do
       auth_stub
@@ -10,7 +10,7 @@ class AuthenticationTest < Minitest::Test
         .with(body: { apiKey: 'wrong', secret: 'abc' })
         .to_return(status: 401, body: 'Invalid request')
 
-      @redox_auth = Redox::Authentication.new
+      @redox_auth = Redox::FHIRAuthentication.new
       @config = Redox.configuration.to_h
     end
 
@@ -20,8 +20,8 @@ class AuthenticationTest < Minitest::Test
 
     describe 'configuration' do
       it 'can set the expiry padding to 0' do
-        Redox::Authentication.token_expiry_padding = 0
-        assert_equal(0, Redox::Authentication.token_expiry_padding)
+        Redox::FHIRAuthentication.token_expiry_padding = 0
+        assert_equal(0, Redox::FHIRAuthentication.token_expiry_padding)
       end
     end
 
@@ -32,7 +32,7 @@ class AuthenticationTest < Minitest::Test
       end
 
       it 'uses refresh endpoint if we already have a token' do
-        Redox::Authentication.token_expiry_padding = 9999
+        Redox::FHIRAuthentication.token_expiry_padding = 9999
 
         @redox_auth.authenticate
         @redox_auth.authenticate
@@ -44,7 +44,7 @@ class AuthenticationTest < Minitest::Test
       end
 
       it 'makes no calls when token wont expire inside padding time' do
-        Redox::Authentication.token_expiry_padding = -60
+        Redox::FHIRAuthentication.token_expiry_padding = -60
 
         @redox_auth.authenticate
         @redox_auth.authenticate
@@ -55,15 +55,15 @@ class AuthenticationTest < Minitest::Test
         assert_equal('let.me.in', @redox_auth.access_token)
       end
 
-      it 'fails with a resonable exception and with nil response' do
+      it 'fails with a reasonable exception and with nil response' do
         @redox_auth.expire!
 
-        key = Redox.configuration.api_key
-        Redox.configuration.api_key = 'wrong'
+        key = Redox.configuration.fhir_client_id
+        Redox.configuration.fhir_client_id = 'wrong'
 
         error = assert_raises(Redox::RedoxException) { @redox_auth.authenticate }
 
-        Redox.configuration.api_key = key
+        Redox.configuration.fhir_client_id = key
 
         assert_match(/Failed Authenticat/, error.message)
         assert_match(/HTTP code: 401/, error.message)
@@ -100,14 +100,14 @@ class AuthenticationTest < Minitest::Test
       end
 
       it 'uses the default' do
-        Redox::Authentication.token_expiry_padding = 9999
+        Redox::FHIRAuthentication.token_expiry_padding = 9999
 
         assert(@redox_auth.expires?)
       end
     end
 
     after do
-      Redox::Authentication.token_expiry_padding = nil
+      Redox::FHIRAuthentication.token_expiry_padding = nil
     end
 
   end

--- a/test/redox/models/patient_test.rb
+++ b/test/redox/models/patient_test.rb
@@ -103,6 +103,7 @@ class PatientTest < Minitest::Test
 
       describe '#query' do
         before do
+          debugger
           @query_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Request::PatientSearch::QUERY_ENDPOINT))
             .with(headers: { 'Authorization' => 'Bearer let.me.in' })
             .to_return(status: 200, body: load_sample('patient_search_single_result.response.json'))

--- a/test/redox/models/patient_test.rb
+++ b/test/redox/models/patient_test.rb
@@ -94,7 +94,7 @@ class PatientTest < Minitest::Test
       before do
         stub_request(:post, /#{Redox::Authentication::AUTH_ENDPOINT}/)
           # .with(body: hash_including({ apiKey: '123'}))
-          .to_return(status: 200, body: { accessToken: 'let.me.in', expires: (Time.now + 60).utc.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), refreshToken: 'rtoken' }.to_json )
+          .to_return(status: 200, body: { access_token: 'let.me.in', expires: (Time.now + 60).utc.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), refreshToken: 'rtoken' }.to_json )
 
         WebMock.after_request do |request, response|
           @request = request

--- a/test/redox/models/patient_test.rb
+++ b/test/redox/models/patient_test.rb
@@ -92,8 +92,8 @@ class PatientTest < Minitest::Test
 
     describe 'redox calls' do
       before do
-        stub_request(:post, /#{Redox::Authentication::BASE_ENDPOINT}/)
-          .with(body: hash_including({ apiKey: '123'}))
+        stub_request(:post, /#{Redox::Authentication::AUTH_ENDPOINT}/)
+          # .with(body: hash_including({ apiKey: '123'}))
           .to_return(status: 200, body: { accessToken: 'let.me.in', expires: (Time.now + 60).utc.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), refreshToken: 'rtoken' }.to_json )
 
         WebMock.after_request do |request, response|
@@ -103,9 +103,8 @@ class PatientTest < Minitest::Test
 
       describe '#query' do
         before do
-          debugger
           @query_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Request::PatientSearch::QUERY_ENDPOINT))
-            .with(headers: { 'Authorization' => 'Bearer let.me.in' })
+            # .with(headers: { 'Authorization' => 'Bearer let.me.in' })
             .to_return(status: 200, body: load_sample('patient_search_single_result.response.json'))
         end
 

--- a/test/redox/models/visit_test.rb
+++ b/test/redox/models/visit_test.rb
@@ -4,7 +4,7 @@ class VisitTest < Minitest::Test
   describe 'visit' do
     let(:visit) { Redox::Models::Visit.new(data) }
     let(:deserialized) { JSON.parse(visit.to_json) }
-    let(:as_json) { visit.as_json }
+    let(:visit_as_json) { visit.as_json }
     let(:data) { {} }
 
     describe 'insurances' do
@@ -143,7 +143,7 @@ class VisitTest < Minitest::Test
 
           describe '#as_json' do
             it 'converts to redox format' do
-              assert_equal(datetime.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), as_json.dig('VisitDateTime'))
+              assert_equal(datetime.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), visit_as_json.dig('VisitDateTime'))
             end
           end
         end
@@ -159,7 +159,7 @@ class VisitTest < Minitest::Test
 
           describe '#as_json' do
             it 'leaves it be' do
-              assert_equal(datetime, as_json.dig('VisitDateTime'))
+              assert_equal(datetime, visit_as_json.dig('VisitDateTime'))
             end
           end
         end
@@ -197,7 +197,7 @@ class VisitTest < Minitest::Test
 
           describe '#as_json' do
             it 'converts to redox format' do
-              assert_equal(datetime.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), as_json.dig('DischargeDateTime'))
+              assert_equal(datetime.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), visit_as_json.dig('DischargeDateTime'))
             end
           end
         end
@@ -213,7 +213,7 @@ class VisitTest < Minitest::Test
 
           describe '#as_json' do
             it 'leaves it be' do
-              assert_equal(datetime, as_json.dig('DischargeDateTime'))
+              assert_equal(datetime, visit_as_json.dig('DischargeDateTime'))
             end
           end
         end

--- a/test/redox_test.rb
+++ b/test/redox_test.rb
@@ -36,8 +36,8 @@ class RedoxTest < Minitest::Test
     end
 
     {
-      api_key: 'a',
-      secret: 'b',
+      fhir_client_id: 'a',
+      fhir_private_key: 'b',
       api_endpoint: 'http://hi.com',
       token_expiry_padding: 123
     }.each do |method, value|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,12 +63,12 @@ end
 def stub_redox(body:)
   body = body.to_json if body.is_a?(Hash)
 
-  stub_request(:post, /#{Redox::Authentication::BASE_ENDPOINT}/)
+  stub_request(:post, /#{Redox::Authentication::AUTH_ENDPOINT}/)
     # .with(body: hash_including({ grant_type: 'client_credentials'}))
     .to_return(status: 200, body: { accessToken: 'let.me.in' }.to_json )
 
   @post_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Connection::DEFAULT_ENDPOINT))
-    .with(headers: { 'Authorization' => 'Bearer let.me.in' })
+    # .with(headers: { 'Authorization' => 'Bearer let.me.in' })
     .to_return(status: 200, body: body)
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,21 @@ require 'minitest/autorun'
 require 'webmock/minitest'
 require 'byebug'
 
-Redox.configuration.api_key = '123'
-Redox.configuration.secret  = 'abc'
+Redox.configuration.fhir_client_id = '123456' * 5
+Redox.configuration.fhir_private_key  = {
+  "p": "7JnNtPpHFQtqRx25HuOAiyLcJ4B_Ol8pYytSitB2C24NJMm9DPV-rhG78c0Q1ZmU9QoPq_wo_QjlrLM35Pux6vOcbMNvqRl4zP5YJNJvSgvz4CGrmLsNqSBPryxOlNf1pnJ3XVFLlIJKy1A1EHJHFPFVVQ8gfXbFmdLQx0jwba8",
+  "kty": "RSA",
+  "q": "uup7I0MPcFjsonGFbaobTr1bmL_e5IxntmQUuwdn7eoNA-dUTcBlyzbHAV4Ar08Z-kU8DEuac7RGaN2OTXmeO94EBwYs9L2RK0YWZEvZT47ziAno5GsHGIL-JyTjEiUzQGlUFCZy4djcnaL6_JBCrz_lyw5vdQPTbR1jzEnsI_s",
+  "d": "rAmW1B9Zqwr4JwTg2nDW-rXP4u1sGr8kQ1G0NlZFfljdBYHRgx1mWk0Cs7GhOKmH1Ux-Sv9EjkiPcejjsYbbMTaUkfg5JMdpz8SFpM6T0gXW9ip3PqhyurtHiSVaGegBlqs9AKUha7nyQGPbwS5XAqkOnwyIggBPQi7PKV6qg2Pp8vTmDaDNDDd73f-AQzfrmRwuJuQ2v2h36hzWUXsN4zlFgHF7UZXxn9f9KN9r90sP_yW3Hijwl38PlbgLXLO4GjTQtBNToaoXHJBtSUB-VirGs9N4hwesJzbF5Hdcs63zrgri_rcumtQ3VHYDehAsee_Qik9EScRVjF3hmDKBGQ",
+  "e": "AQAB",
+  "use": "sig",
+  "kid": "sig-1708984111",
+  "qi": "VQTe48obuLv-NxRAfEBqdN_VOPLjbCAA2_y5xDqHW9hiryb5uAjOoRYVa_BZdSvWDe4XiYyBOnmuQPqC3kdB6Fo0yL2K0bkv5u4OvTN2E7oaq7iBzAukutkfA-Da5gvDSvabeUes_2bGc5mKdKgRSQT1Qzp1wn3qSuw0Sng6IQ",
+  "dp": "Y5vQ7btch7CZmr0ZvbZb3LfdZcgESEfd_cE0a_qdZ-x6Hh3MuJL2NUSEEqWZy8Nv4cXNmUN84iKHxzBgfMe2PMs49NVGwjNWFz-RTldFwS_NCXRDcPZ3JtfSlFYb8zAEXIHeXOwn3KsJ4BSxcm4aHOgJW9kVfZyuTjdh7DR5_EM",
+  "alg": "RS384",
+  "dq": "pysQ6C-QvkT5lir7T2IkvB5Erm9jtHoSQ6Bsnfz4qWJ7M3OQBV2-bKnX_9QHvsJ7FEcZdlGjmDmyAxWrsITFzPs6FOIkENr923r6iccAWtQZ4CAkxy0lknmNPosR_meA1-mbxc3BT1X5sY5S9NE8oqn-JcYKTtgWHm97kvjGFkM",
+  "n": "rMB12gIcA_DLKEF88Rf4s9p7Bn4oFnLsN5iaevgtlLEuPSNSRbRtw3eFDwoxqqzCtC5cfQlvgSdVNlemC4q5BzdiMh2mYnxt0wLidCq9tK44u9eKvXOBNXRjBNwDSrrspEIRWi8_5kA1svjen9asmwuXgeYoTQoR4Vm9_pBQFofWYJQIjNEzdPD0G9o2_haqOP0nto8kQtJXsYQAkyDZPoZXhCr7gIt4n5pq7DvUXzT39qHrdZ3b2pTBCmgcTrKBWwpMVOOKWXlCa0sPjb_xD83QC70UUAMuSMdJg-5rPzEy-A_Sn9DnIBny6V8KgfnS6t81pmYS6db5ltO9Zw53lQ"
+}.to_json
 
 # HTTParty has added a really annoying deprecation warning in 0.18.1
 #  that flags even though we aren't using the method and is using
@@ -47,11 +60,11 @@ def load_sample(file, parse: false)
   return file_contents
 end
 
-def stub_redox(status: 200, body: , endpoint: Redox::Connection::DEFAULT_ENDPOINT )
+def stub_redox(body:)
   body = body.to_json if body.is_a?(Hash)
 
   stub_request(:post, /#{Redox::Authentication::BASE_ENDPOINT}/)
-    .with(body: hash_including({ apiKey: '123'}))
+    # .with(body: hash_including({ grant_type: 'client_credentials'}))
     .to_return(status: 200, body: { accessToken: 'let.me.in' }.to_json )
 
   @post_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Connection::DEFAULT_ENDPOINT))
@@ -61,12 +74,12 @@ end
 
 def auth_stub
   @auth_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Authentication::AUTH_ENDPOINT))
-    .with(body: { apiKey: '123', secret: 'abc' })
+    # .with(body: { apiKey: '123', secret: 'abc' })
     .to_return(status: 200, body: { accessToken: 'let.me.in', expires: (Time.now + 60).utc.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), refreshToken: 'rtoken' }.to_json )
 end
 
 def refresh_stub
-  @refresh_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Authentication::REFRESH_ENDPOINT))
-    .with(body: { apiKey: '123', refreshToken: 'rtoken' })
+  @refresh_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::FHIRAuthentication::REFRESH_ENDPOINT))
+    # .with(body: { apiKey: '123', refreshToken: 'rtoken' })
     .to_return(status: 200, body: { accessToken: 'let.me.in.again', expires: (Time.now + 60).utc.strftime(Redox::Models::Meta::TO_DATETIME_FORMAT), refreshToken: 'rtoken' }.to_json )
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,25 +66,16 @@ def stub_redox(body:)
   body = body.to_json if body.is_a?(Hash)
 
   @auth_stub = stub_request(:post, /#{Redox::Authentication::AUTH_ENDPOINT}/)
-    # .with(body: hash_including({ grant_type: 'client_credentials'}))
     .to_return(status: 200, body: { access_token: 'let.me.in', expires_in: 300 }.to_json )
 
   @post_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Connection::DEFAULT_ENDPOINT))
-    # .with(headers: { 'Authorization' => 'Bearer let.me.in' })
     .to_return(status: 200, body: body)
 end
 
 def auth_stub
   @auth_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::Authentication::AUTH_ENDPOINT))
-    # .with(body: { apiKey: '123', secret: 'abc' })
     .to_return(status: 200, body: { access_token: 'let.me.in', expires_in: 300, refreshToken: 'rtoken' }.to_json )
 end
-
-# def refresh_stub
-#   @refresh_stub = stub_request(:post, File.join(Redox.configuration.api_endpoint, Redox::FHIRAuthentication::REFRESH_ENDPOINT))
-#     # .with(body: { apiKey: '123', refreshToken: 'rtoken' })
-#     .to_return(status: 200, body: { access_token: 'let.me.in.again', expires_in: 300, refreshToken: 'rtoken' }.to_json )
-# end
 
 def legacy_stub_redox(status: 200, body:, endpoint: Redox::LegacyConnection::DEFAULT_ENDPOINT)
   body = body.to_json if body.is_a?(Hash)
@@ -125,7 +116,6 @@ class Minitest::Spec
     remove_request_stub(@legacy_post_stub) if @legacy_post_stub
     remove_request_stub(@legacy_refresh_stub) if @legacy_refresh_stub
 
-    # debugger if @auth_stub
     remove_request_stub(@auth_stub) if @auth_stub
     remove_request_stub(@post_stub) if @post_stub
   end


### PR DESCRIPTION
The current redox gem only supports FHIR legacy API keys. This adds oauth authentication support as well as adds support for hitting the Redox platform APIs as well as the existing FHIR Redox APIs.

Coauthor: @Zuzah
Sponsored by @ChorusInnovations.